### PR TITLE
chore: Put TS subpath exports first

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,34 +17,34 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./jsx-dev-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
       "require": "./dist/jsx-runtime.js",
-      "import": "./dist/jsx-runtime.mjs",
-      "types": "./dist/jsx-runtime.d.ts"
+      "import": "./dist/jsx-runtime.mjs"
     },
     "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
       "require": "./dist/jsx-runtime.js",
-      "import": "./dist/jsx-runtime.mjs",
-      "types": "./dist/jsx-runtime.d.ts"
+      "import": "./dist/jsx-runtime.mjs"
     },
     "./manager": {
+      "types": "./dist/manager.d.ts",
       "require": "./dist/manager.js",
-      "import": "./dist/manager.mjs",
-      "types": "./dist/manager.d.ts"
+      "import": "./dist/manager.mjs"
     },
     "./preset": {
+      "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js",
-      "import": "./dist/preset.mjs",
-      "types": "./dist/preset.d.ts"
+      "import": "./dist/preset.mjs"
     },
     "./preview": {
+      "types": "./dist/preview.d.ts",
       "require": "./dist/preview.js",
-      "import": "./dist/preview.mjs",
-      "types": "./dist/preview.d.ts"
+      "import": "./dist/preview.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.3--canary.9.216d149.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-vue-mdx@1.0.3--canary.9.216d149.0
  # or 
  yarn add storybook-addon-vue-mdx@1.0.3--canary.9.216d149.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
