### PR TITLE
fix: Support components without a scope ID

### DIFF
--- a/src/components/StylelessButton.vue
+++ b/src/components/StylelessButton.vue
@@ -1,0 +1,10 @@
+<script setup>
+const emit = defineEmits(['click'])
+const onClick = () => emit('click')
+</script>
+
+<template>
+  <button type="button" @click="onClick">
+    <slot />
+  </button>
+</template>

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -9,6 +9,9 @@ const isLikelyVueComponent = (nodeType: any) => {
     if (!!nodeType.__name && !!nodeType.__scopeId) {
       return true
     }
+    if (!!nodeType.__name && !!nodeType.__hmrId) {
+      return true
+    }
     if (!!nodeType.name && !!nodeType.setup) {
       return true
     }

--- a/src/stories/VueComponentWithoutStyle.mdx
+++ b/src/stories/VueComponentWithoutStyle.mdx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/blocks'
+
+import DemoStylelessButton from '../components/StylelessButton.vue'
+import { Fragment } from 'react'
+import { Fragment as VueFragment } from 'vue'
+
+<Meta title="Vue/Without style tag" />
+
+# Vue component without style tag
+
+<DemoStylelessButton>Click me</DemoStylelessButton>


### PR DESCRIPTION
Closes #11.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.5--canary.12.dedbfa7.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-vue-mdx@1.0.5--canary.12.dedbfa7.0
  # or 
  yarn add storybook-addon-vue-mdx@1.0.5--canary.12.dedbfa7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
