### PR TITLE
fix(jsx-runtime): Introduce explicit jsxs to resolve missing key warning

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,11 +1,12 @@
 import {
-  ComponentClass,
   createElement,
   Fragment,
+  ElementType,
   Key,
   ReactNode,
   type FunctionComponent,
 } from 'react'
+import { jsxs as reactJsxs } from 'react/jsx-runtime'
 import { applyPureVueInReact } from 'veaury'
 import { h, Fragment as VueFragment } from 'vue'
 import { getGlobals } from './globals'
@@ -61,13 +62,8 @@ const isLikelyVueFragment = (nodeType: unknown) =>
   nodeType === _vueFragment.type
 
 const jsx = (
-  nodeType:
-    | string
-    | ComponentClass<{ children: undefined; key: Key }, unknown>
-    | FunctionComponent<{ children: undefined; key: Key }>,
-  props: object & {
-    children?: ReactNode
-  },
+  nodeType: ElementType,
+  props: { children?: ReactNode; [key: string]: unknown },
   key: Key,
 ) => {
   const children = 'children' in props ? props.children : undefined
@@ -93,4 +89,31 @@ const jsx = (
   return createElement(nodeType, newProps, children)
 }
 
-export { Fragment, jsx, jsx as jsxs, jsx as jsxDEV }
+const jsxs = (
+  nodeType: ElementType,
+  props: { children?: ReactNode; [key: string]: unknown },
+  key?: Key,
+) => {
+  const children = 'children' in props ? props.children : undefined
+  const newProps = { ...props, children: undefined, key }
+  if (isLikelyVueComponent(nodeType)) {
+    const vueMdxOptions = getGlobals()
+
+    // TODO optimise / memoise wrappedNode
+    const wrappedNode = applyPureVueInReact(nodeType, vueMdxOptions)
+
+    return createElement(
+      wrappedNode as FunctionComponent<unknown>,
+      newProps,
+      children,
+    )
+  }
+
+  if (isLikelyVueFragment(nodeType)) {
+    return createElement(Fragment, newProps, children)
+  }
+
+  return reactJsxs(nodeType, props, key)
+}
+
+export { Fragment, jsx, jsxs, jsx as jsxDEV }


### PR DESCRIPTION
When rendering the MDX files, React logs **_Each child in a list should have a unique "key" prop_** warnings when not in production. 

The addon currently exports jsx as jsxs, meaning both calls go through the same function which uses createElement directly. createElement never calls React's internal validateChildKeys, which means _store.validated is never set to true on child elements. This is only called by the react/jsx-runtime jsxs, it iterates the static children array and sets _store.validated = true on each child. 

By aliasing jsx as jsxs with the custom jsx function which only uses createElement, validateChildKeys was never called and React's reconciler had no way of knowing the array had been validated.

When React's reconciler processes the children array it checks:
```typescript
function warnForMissingKey(child) {
  if (!child._store || child._store.validated || child.key != null) {
    return // skip warning
  }
  // warn...
}
```

This PR adds an explicit jsxs instead of aliasing jsx. For non-Vue elements it delegates to reactJsxs from react/jsx-runtime, which runs validateChildKeys on each child and sets _store.validated = true, telling React's reconciler the array has been validated.

Vue components and Fragments still go through createElement to preserve the original behaviour. By the time jsxs is called, Vue components are already wrapped by the custom jsx so i dont see a concern for the vue related rendering since that method will hit isLikelyVueComponent. 

There is a bit of duplication between the two methods now which could be improved, but i let that be as it is explicit. 

### Question:
Was there a deliberate reason for using createElement directly rather than delegating to react/jsx-runtime? Just to make sure there isn't a known issue i am missing.

<img width="1349" height="885" alt="Screenshot 2026-03-11 at 14 49 22" src="https://github.com/user-attachments/assets/e880631e-ba19-4aa6-9741-6735eb980852" />
